### PR TITLE
Handle large Vision writes safely

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,7 @@ jobs:
           ${{ matrix.tag }} go build -o ./mio-${{ matrix.dickname }} .
 
       - name: Release
+        if: github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@master
         with:
           tag_name: V${{ steps.get_version.outputs.version }}
@@ -68,6 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Send to mirror
+        if: github.ref == 'refs/heads/main'
         uses: moaeiou/moaeiou/actions/rsync@main
         with:
           local: ./mio-${{ matrix.dickname }}

--- a/protocol/tunnel_test.go
+++ b/protocol/tunnel_test.go
@@ -323,6 +323,41 @@ func TestVisionConnPreservesBytesAcrossRawSwitch(t *testing.T) {
 	}
 }
 
+func TestVisionConnLargeWrite(t *testing.T) {
+	left, right := net.Pipe()
+	client := newVision(left)
+	server := newVision(right)
+	defer client.Close()
+	defer server.Close()
+	payload := make([]byte, visionMaxChunk+123)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+	type writeResult struct {
+		n   int
+		err error
+	}
+	done := make(chan writeResult, 1)
+	go func() {
+		n, err := client.Write(payload)
+		done <- writeResult{n: n, err: err}
+	}()
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(server, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("vision framing changed payload")
+	}
+	result := <-done
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if result.n != len(payload) {
+		t.Fatalf("Write() = %d, want %d", result.n, len(payload))
+	}
+}
+
 func TestQUICAuthenticatedTunnelAndRelay(t *testing.T) {
 	const keyHex = "93cb499ed398baa3f36f76c20483989ec911f8fe5ccd43a3c5f58952ade56435"
 	key, err := decodeKey(keyHex)

--- a/protocol/vision.go
+++ b/protocol/vision.go
@@ -37,37 +37,43 @@ func (c *visionConn) Write(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	if c.writeRaw {
-		return c.Conn.Write(p)
-	}
-	if c.written >= visionBudget {
-		packet := append([]byte{visionRawFrame, 0, 0, 0, 0}, p...)
-		if err := writeAll(c.Conn, packet); err != nil {
-			return 0, err
+	written := 0
+	for len(p) > 0 {
+		if c.writeRaw {
+			n, err := c.Conn.Write(p)
+			return written + n, err
 		}
-		c.writeRaw = true
-		return len(p), nil
-	}
-	chunkSize := min(len(p), visionMaxChunk)
-	paddingSize, err := randBetween(0, visionMaxPadding)
-	if err != nil {
-		return 0, err
-	}
-	frame := make([]byte, 5+chunkSize+paddingSize)
-	frame[0] = visionDataFrame
-	binary.BigEndian.PutUint16(frame[1:3], uint16(chunkSize))
-	binary.BigEndian.PutUint16(frame[3:5], uint16(paddingSize))
-	copy(frame[5:], p[:chunkSize])
-	if paddingSize > 0 {
-		if _, err := rand.Read(frame[5+chunkSize:]); err != nil {
-			return 0, err
+		if c.written >= visionBudget {
+			packet := append([]byte{visionRawFrame, 0, 0, 0, 0}, p...)
+			if err := writeAll(c.Conn, packet); err != nil {
+				return written, err
+			}
+			c.writeRaw = true
+			return written + len(p), nil
 		}
+		chunkSize := min(len(p), visionMaxChunk)
+		paddingSize, err := randBetween(0, visionMaxPadding)
+		if err != nil {
+			return written, err
+		}
+		frame := make([]byte, 5+chunkSize+paddingSize)
+		frame[0] = visionDataFrame
+		binary.BigEndian.PutUint16(frame[1:3], uint16(chunkSize))
+		binary.BigEndian.PutUint16(frame[3:5], uint16(paddingSize))
+		copy(frame[5:], p[:chunkSize])
+		if paddingSize > 0 {
+			if _, err := rand.Read(frame[5+chunkSize:]); err != nil {
+				return written, err
+			}
+		}
+		if err := writeAll(c.Conn, frame); err != nil {
+			return written, err
+		}
+		c.written += chunkSize
+		written += chunkSize
+		p = p[chunkSize:]
 	}
-	if err := writeAll(c.Conn, frame); err != nil {
-		return 0, err
-	}
-	c.written += chunkSize
-	return chunkSize, nil
+	return written, nil
 }
 
 func (c *visionConn) Read(p []byte) (int, error) {


### PR DESCRIPTION
`visionConn.Write` capped framed writes at 65,535 bytes and could return a short count with a nil error. That breaks the `io.Writer` contract and can surface as `io.ErrShortWrite` in callers.

This change consumes the remaining payload in the same call while preserving the existing framed-to-raw transition. It also adds a regression test that writes past the frame limit and checks both the reported byte count and the received payload.

Release and mirror steps are now limited to `main`, so pushes to feature branches can still build without replacing release assets or syncing the mirror.

Checks run:
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- shuffled tests, 100 runs
- all nine workflow build targets
- `actionlint`